### PR TITLE
fix(#43, #48): light mode all screens + awards view fix

### DIFF
--- a/ffc/src/index.css
+++ b/ffc/src/index.css
@@ -7607,3 +7607,109 @@ body.is-leaderboard-landscape .lb-table-grid {
   /* Stable header footprint regardless of avatar/bell loading state. */
   min-height: 48px;
 }
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * Light-mode overrides — Issue #43
+ *
+ * All per-screen brand blocks hardcode dark CSS tokens so they win over
+ * :root.theme-light. These counterpart rules restore light values whenever
+ * html carries .theme-light. Same block also nested inside the theme-auto
+ * media query so System preference works identically.
+ *
+ * ch-root uses --ch-* prefix tokens and gets its own block below.
+ * mer-screen lives in match-entry-review.css and is overridden there.
+ * ───────────────────────────────────────────────────────────────────────── */
+
+/* Standard screens (14 total) */
+:root.theme-light .po-screen,
+:root.theme-light .lb-screen,
+:root.theme-light .pf-screen,
+:root.theme-light .mt-screen,
+:root.theme-light .lr-screen,
+:root.theme-light .st-screen,
+:root.theme-light .aw-screen,
+:root.theme-light .rs-screen,
+:root.theme-light .py-screen,
+:root.theme-light .admin-players,
+:root.theme-light .admin-matches,
+:root.theme-light .as-root,
+:root.theme-light .ah-root {
+  --bg: #fdfbf5;
+  --surface: rgba(255, 255, 255, 0.92);
+  --surface-2: #f4f1e7;
+  --border: #e3dfd2;
+  --text: #0e1826;
+  --text-muted: #6b7280;
+  --accent: #c99a30;
+  --success: #1d8a60;
+  --warn: #9a6e20;
+  --warning: #9a6e20;
+  --danger: #c41c30;
+  --skel-a: rgba(14, 24, 38, 0.04);
+  --skel-b: rgba(14, 24, 38, 0.10);
+}
+
+/* CaptainHelper — uses --ch-* prefix */
+:root.theme-light .ch-root {
+  --ch-paper: #fdfbf5;
+  --ch-surface: rgba(255, 255, 255, 0.92);
+  --ch-surface-soft: rgba(255, 255, 255, 0.70);
+  --ch-surface-deep: rgba(244, 241, 231, 0.85);
+  --ch-ink: #0e1826;
+  --ch-ink-soft: rgba(14, 24, 38, 0.82);
+  --ch-ink-mute: rgba(14, 24, 38, 0.62);
+  --ch-ink-faint: rgba(14, 24, 38, 0.42);
+  --ch-border: rgba(14, 24, 38, 0.14);
+  --ch-border-strong: rgba(14, 24, 38, 0.28);
+  --ch-divider: rgba(14, 24, 38, 0.16);
+  --ch-warn-weak: rgba(154, 110, 32, 0.12);
+  --ch-warn-line: rgba(154, 110, 32, 0.40);
+  --ch-success-weak: rgba(29, 138, 96, 0.12);
+}
+
+/* System / auto theme — re-apply screen overrides when OS prefers light */
+@media (prefers-color-scheme: light) {
+  :root.theme-auto .po-screen,
+  :root.theme-auto .lb-screen,
+  :root.theme-auto .pf-screen,
+  :root.theme-auto .mt-screen,
+  :root.theme-auto .lr-screen,
+  :root.theme-auto .st-screen,
+  :root.theme-auto .aw-screen,
+  :root.theme-auto .rs-screen,
+  :root.theme-auto .py-screen,
+  :root.theme-auto .admin-players,
+  :root.theme-auto .admin-matches,
+  :root.theme-auto .as-root,
+  :root.theme-auto .ah-root {
+    --bg: #fdfbf5;
+    --surface: rgba(255, 255, 255, 0.92);
+    --surface-2: #f4f1e7;
+    --border: #e3dfd2;
+    --text: #0e1826;
+    --text-muted: #6b7280;
+    --accent: #c99a30;
+    --success: #1d8a60;
+    --warn: #9a6e20;
+    --warning: #9a6e20;
+    --danger: #c41c30;
+    --skel-a: rgba(14, 24, 38, 0.04);
+    --skel-b: rgba(14, 24, 38, 0.10);
+  }
+  :root.theme-auto .ch-root {
+    --ch-paper: #fdfbf5;
+    --ch-surface: rgba(255, 255, 255, 0.92);
+    --ch-surface-soft: rgba(255, 255, 255, 0.70);
+    --ch-surface-deep: rgba(244, 241, 231, 0.85);
+    --ch-ink: #0e1826;
+    --ch-ink-soft: rgba(14, 24, 38, 0.82);
+    --ch-ink-mute: rgba(14, 24, 38, 0.62);
+    --ch-ink-faint: rgba(14, 24, 38, 0.42);
+    --ch-border: rgba(14, 24, 38, 0.14);
+    --ch-border-strong: rgba(14, 24, 38, 0.28);
+    --ch-divider: rgba(14, 24, 38, 0.16);
+    --ch-warn-weak: rgba(154, 110, 32, 0.12);
+    --ch-warn-line: rgba(154, 110, 32, 0.40);
+    --ch-success-weak: rgba(29, 138, 96, 0.12);
+  }
+}

--- a/ffc/src/lib/AppContext.tsx
+++ b/ffc/src/lib/AppContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
 import type { Session } from '@supabase/supabase-js'
 import { supabase } from './supabase'
+import { applyThemeClass } from './theme'
 
 /* Plain-object Context per CLAUDE.md Rule #8 — no useMemo cascade.
  *
@@ -90,7 +91,7 @@ export function AppProvider({ children }: AppProviderProps) {
     setProfileLoading(true)
     supabase
       .from('profiles')
-      .select('id, role, reject_reason')
+      .select('id, role, reject_reason, theme_preference')
       .eq('auth_user_id', userId)
       .maybeSingle()
       .then(({ data, error }) => {
@@ -118,6 +119,7 @@ export function AppProvider({ children }: AppProviderProps) {
         } else if (data) {
           setProfileId(data.id)
           setRole(data.role as UserRole)
+          applyThemeClass(data.theme_preference ?? 'dark')
         } else {
           setProfileId(null)
           setRole(null)

--- a/ffc/src/lib/theme.ts
+++ b/ffc/src/lib/theme.ts
@@ -1,0 +1,11 @@
+import type { Database } from './database.types'
+
+export type ThemePreference = Database['public']['Enums']['theme_preference']
+
+export function applyThemeClass(theme: ThemePreference): void {
+  const root = document.documentElement
+  root.classList.remove('theme-light', 'theme-dark', 'theme-auto')
+  if (theme === 'light') root.classList.add('theme-light')
+  else if (theme === 'system') root.classList.add('theme-auto')
+  // 'dark' is the CSS default — no class needed
+}

--- a/ffc/src/pages/Profile.tsx
+++ b/ffc/src/pages/Profile.tsx
@@ -4,6 +4,7 @@ import { supabase } from '../lib/supabase'
 import { useApp } from '../lib/AppContext'
 import { MatchDetailSheet } from '../components/MatchDetailSheet'
 import type { Database } from '../lib/database.types'
+import { applyThemeClass } from '../lib/theme'
 import { AvatarSheet, compressImage } from './ProfileAvatarSheet'
 
 /* §3.14 Player Profile — Phase 1 Depth-B slice (S023).
@@ -771,11 +772,7 @@ export function Profile() {
     setEditTheme(val)
     if (!selfProfileId) return
     await supabase.from('profiles').update({ theme_preference: val }).eq('id', selfProfileId)
-    const root = document.documentElement
-    root.classList.remove('theme-light', 'theme-dark', 'theme-auto')
-    if (val === 'light') root.classList.add('theme-light')
-    else if (val === 'dark') root.classList.add('theme-dark')
-    else root.classList.add('theme-auto')
+    applyThemeClass(val)
   }
 
   async function handleSortChange(val: SortKey) {

--- a/ffc/src/pages/Settings.tsx
+++ b/ffc/src/pages/Settings.tsx
@@ -10,6 +10,7 @@ import {
 } from '../lib/pushSubscribe'
 import { IosInstallPrompt } from '../components/IosInstallPrompt'
 import type { Database } from '../lib/database.types'
+import { applyThemeClass } from '../lib/theme'
 
 /* §3.16 Settings — Phase 1 Depth-B (S024 slice 4).
  * Five rows: Theme · Push · Positions · Display name · Account.
@@ -73,13 +74,6 @@ const PUSH_EVENTS: { key: keyof PushPrefs; label: string }[] = [
   { key: 'dropout_after_lock', label: 'Dropout after lock' },
 ]
 
-function applyThemeClass(theme: ThemePreference) {
-  const root = document.documentElement
-  root.classList.remove('theme-light', 'theme-dark', 'theme-auto')
-  if (theme === 'light') root.classList.add('theme-light')
-  else if (theme === 'dark') root.classList.add('theme-dark')
-  else root.classList.add('theme-auto')
-}
 
 function normalisePushPrefs(raw: unknown): PushPrefs {
   if (raw && typeof raw === 'object') {

--- a/ffc/src/styles/match-entry-review.css
+++ b/ffc/src/styles/match-entry-review.css
@@ -347,3 +347,38 @@
   border-color: var(--accent);
   font-weight: 600;
 }
+
+/* Light-mode token override — Issue #43 */
+:root.theme-light .mer-screen {
+  --bg: #fdfbf5;
+  --surface: rgba(255, 255, 255, 0.92);
+  --surface-2: #f4f1e7;
+  --border: #e3dfd2;
+  --text: #0e1826;
+  --text-muted: #6b7280;
+  --accent: #c99a30;
+  --success: #1d8a60;
+  --warn: #9a6e20;
+  --warning: #9a6e20;
+  --danger: #c41c30;
+  --skel-a: rgba(14, 24, 38, 0.06);
+  --skel-b: rgba(14, 24, 38, 0.10);
+}
+
+@media (prefers-color-scheme: light) {
+  :root.theme-auto .mer-screen {
+    --bg: #fdfbf5;
+    --surface: rgba(255, 255, 255, 0.92);
+    --surface-2: #f4f1e7;
+    --border: #e3dfd2;
+    --text: #0e1826;
+    --text-muted: #6b7280;
+    --accent: #c99a30;
+    --success: #1d8a60;
+    --warn: #9a6e20;
+    --warning: #9a6e20;
+    --danger: #c41c30;
+    --skel-a: rgba(14, 24, 38, 0.06);
+    --skel-b: rgba(14, 24, 38, 0.10);
+  }
+}

--- a/ffc/src/styles/matches.css
+++ b/ffc/src/styles/matches.css
@@ -168,3 +168,44 @@
 .mt-icon-motm    { font-size: 10px; line-height: 1; color: #e5ba5b; }
 .mt-player-row--no-goal .mt-ps-goals { visibility: hidden; }
 .mt-player-empty { font-size: 11px; color: #3d4f65; font-style: italic; padding: 6px 10px; }
+
+/* Light-mode overrides for hardcoded card colors — Issue #43 */
+:root.theme-light .mt-card {
+  background: #ffffff;
+  border-color: rgba(14, 24, 38, 0.12);
+  color: #0e1826;
+}
+:root.theme-light .mt-card-banner {
+  background: rgba(0, 80, 200, 0.06);
+  border-bottom-color: rgba(0, 80, 200, 0.14);
+}
+:root.theme-light .mt-card-banner-title { color: #1a5bbf; }
+:root.theme-light .mt-card-banner-date  { color: #5c6b7a; }
+:root.theme-light .mt-splitc-half--white { background: rgba(14, 24, 38, 0.04); }
+:root.theme-light .mt-splitc-half--black { background: rgba(14, 24, 38, 0.08); }
+:root.theme-light .mt-splitc-team        { color: #3d4f65; }
+:root.theme-light .mt-score-box          { background: rgba(14, 24, 38, 0.06); }
+:root.theme-light .mt-score-num          { color: #0e1826; }
+:root.theme-light .mt-player-empty       { color: #7a8fa5; }
+:root.theme-light .mt-icon-injury        { color: #b07040; }
+
+@media (prefers-color-scheme: light) {
+  :root.theme-auto .mt-card {
+    background: #ffffff;
+    border-color: rgba(14, 24, 38, 0.12);
+    color: #0e1826;
+  }
+  :root.theme-auto .mt-card-banner {
+    background: rgba(0, 80, 200, 0.06);
+    border-bottom-color: rgba(0, 80, 200, 0.14);
+  }
+  :root.theme-auto .mt-card-banner-title { color: #1a5bbf; }
+  :root.theme-auto .mt-card-banner-date  { color: #5c6b7a; }
+  :root.theme-auto .mt-splitc-half--white { background: rgba(14, 24, 38, 0.04); }
+  :root.theme-auto .mt-splitc-half--black { background: rgba(14, 24, 38, 0.08); }
+  :root.theme-auto .mt-splitc-team        { color: #3d4f65; }
+  :root.theme-auto .mt-score-box          { background: rgba(14, 24, 38, 0.06); }
+  :root.theme-auto .mt-score-num          { color: #0e1826; }
+  :root.theme-auto .mt-player-empty       { color: #7a8fa5; }
+  :root.theme-auto .mt-icon-injury        { color: #b07040; }
+}

--- a/supabase/migrations/0069_awards_view_friendly_noshows.sql
+++ b/supabase/migrations/0069_awards_view_friendly_noshows.sql
@@ -1,0 +1,98 @@
+-- 0069_awards_view_friendly_noshows.sql
+-- Fix issue #48: v_season_award_winners_live was counting friendly matches
+-- and no-show ghost entries, causing awards to diverge from the leaderboard.
+-- Align with v_season_standings: join matchdays, filter NOT is_friendly,
+-- filter NOT is_no_show.
+
+CREATE OR REPLACE VIEW v_season_award_winners_live AS
+WITH base AS (
+  SELECT
+    m.season_id,
+    mp.profile_id,
+    pr.display_name,
+    COUNT(*) FILTER (WHERE m.result = 'win_white' AND mp.team = 'white')
+      + COUNT(*) FILTER (WHERE m.result = 'win_black' AND mp.team = 'black') AS wins,
+    COUNT(*) FILTER (WHERE m.result = 'draw') AS draws,
+    COUNT(*) FILTER (WHERE m.result = 'win_white' AND mp.team = 'black')
+      + COUNT(*) FILTER (WHERE m.result = 'win_black' AND mp.team = 'white') AS losses,
+    COALESCE(SUM(mp.goals), 0)::int AS goals,
+    COALESCE(SUM(mp.yellow_cards), 0)::int AS yellows,
+    COALESCE(SUM(mp.red_cards), 0)::int AS reds,
+    COUNT(*) FILTER (WHERE m.motm_user_id = mp.profile_id)::int AS motms,
+    COUNT(*)::int AS matches_played
+  FROM matches m
+  JOIN matchdays md ON md.id = m.matchday_id
+  JOIN match_players mp ON mp.match_id = m.id
+  JOIN profiles pr ON pr.id = mp.profile_id
+  WHERE m.approved_at IS NOT NULL
+    AND mp.profile_id IS NOT NULL
+    AND pr.deleted_at IS NULL
+    AND NOT md.is_friendly
+    AND NOT mp.is_no_show
+  GROUP BY m.season_id, mp.profile_id, pr.display_name
+),
+scored AS (
+  SELECT *,
+    (wins * 3 + draws) AS points,
+    (yellows + reds) AS total_cards
+  FROM base
+),
+ballon AS (
+  SELECT *,
+    ROW_NUMBER() OVER (PARTITION BY season_id ORDER BY points DESC, wins DESC, total_cards ASC, display_name ASC) AS rn
+  FROM scored
+),
+boot AS (
+  SELECT *,
+    ROW_NUMBER() OVER (PARTITION BY season_id ORDER BY goals DESC, wins DESC, total_cards ASC, display_name ASC) AS rn
+  FROM scored
+),
+motm AS (
+  SELECT *,
+    ROW_NUMBER() OVER (PARTITION BY season_id ORDER BY motms DESC, wins DESC, total_cards ASC, display_name ASC) AS rn
+  FROM scored
+)
+SELECT
+  b1.season_id,
+  'ballon_dor'::text AS award_kind,
+  b1.profile_id AS winner_profile_id,
+  b2.profile_id AS runner_up_profile_id,
+  b1.points::numeric AS metric_value,
+  b2.points::numeric AS runner_up_metric,
+  jsonb_build_object(
+    'wins', b1.wins, 'draws', b1.draws, 'losses', b1.losses,
+    'matches_played', b1.matches_played,
+    'win_pct', CASE WHEN b1.matches_played > 0 THEN ROUND((b1.wins::numeric / b1.matches_played) * 100) ELSE 0 END
+  ) AS meta
+FROM ballon b1
+LEFT JOIN ballon b2 ON b2.season_id = b1.season_id AND b2.rn = 2
+WHERE b1.rn = 1
+UNION ALL
+SELECT
+  b1.season_id,
+  'golden_boot'::text,
+  b1.profile_id,
+  b2.profile_id,
+  b1.goals::numeric,
+  b2.goals::numeric,
+  jsonb_build_object(
+    'matches_played', b1.matches_played,
+    'goals_per_match', CASE WHEN b1.matches_played > 0 THEN ROUND(b1.goals::numeric / b1.matches_played, 2) ELSE 0 END
+  )
+FROM boot b1
+LEFT JOIN boot b2 ON b2.season_id = b1.season_id AND b2.rn = 2
+WHERE b1.rn = 1
+UNION ALL
+SELECT
+  m1.season_id,
+  'most_motm'::text,
+  m1.profile_id,
+  m2.profile_id,
+  m1.motms::numeric,
+  m2.motms::numeric,
+  jsonb_build_object('matches_played', m1.matches_played)
+FROM motm m1
+LEFT JOIN motm m2 ON m2.season_id = m1.season_id AND m2.rn = 2
+WHERE m1.rn = 1;
+
+GRANT SELECT ON v_season_award_winners_live TO authenticated;


### PR DESCRIPTION
## Summary
- **#43 Light/dark mode**: theme now applies to every in-app screen (was only header/footer). Two root causes fixed: (1) per-screen CSS brand blocks overrode `:root.theme-light` — added `.theme-light` counterpart blocks for all 15 screens; (2) saved theme preference wasn't applied on app load — AppContext now reads and applies `theme_preference` immediately on login.
- **#48 Season awards**: awards view now excludes friendly matches and no-show players, aligning it with the leaderboard (`v_season_standings` has had these filters since mig 0013 — awards never got them).

## Changes
- `ffc/src/lib/theme.ts` — new shared `applyThemeClass()` utility
- `ffc/src/lib/AppContext.tsx` — apply saved theme on profile load
- `ffc/src/pages/Settings.tsx` + `Profile.tsx` — use shared utility
- `ffc/src/index.css` — light-mode token overrides for 14 screens + `.ch-root`
- `ffc/src/styles/match-entry-review.css` — light-mode overrides for `.mer-screen`
- `ffc/src/styles/matches.css` — light-mode overrides for hardcoded card colors
- `supabase/migrations/0069_awards_view_friendly_noshows.sql` — fix #48

## Test plan
- [ ] Switch to Light mode in Settings → all content screens (Poll, Leaderboard, Matches, Profile, Awards, Admin, etc.) show cream background + dark text
- [ ] Close and reopen the app → theme persists without needing to re-toggle
- [ ] Awards page → stats aggregate all non-friendly games (not just last game)
- [ ] Leaderboard standings and Awards leaders match the same player rankings
- [ ] Migration 0069 applied: `npx supabase db push --linked`

Closes #43
Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)